### PR TITLE
Fix Gallery and About Us routings + Remove Space Pods Option

### DIFF
--- a/index.html
+++ b/index.html
@@ -522,7 +522,7 @@ $(document).ready(function () {
         
       
         
-          <div class="header-nav-folder-item">
+          <!-- <div class="header-nav-folder-item">
             <a
               href=""
               
@@ -531,7 +531,7 @@ $(document).ready(function () {
                 Designer Pod
               </span>
             </a>
-          </div>
+          </div> -->
         
         
       
@@ -541,7 +541,7 @@ $(document).ready(function () {
   
     <div class="header-nav-item header-nav-item--collection">
       <a
-        href=""
+        href="#footer-sections"
         data-animation-role="header-element"
         
       >
@@ -765,7 +765,7 @@ $(document).ready(function () {
                 href=""
                 
               >
-                <span class="header-nav-folder-item-content">
+                <span class="header-nav-folder-item-content" data-animation-role="header-element">
                   PORTABLE OFFICE
                 </span>
               </a>
@@ -6200,76 +6200,7 @@ id="Gallery"
   <h2 style="text-align:center;white-space:pre-wrap;">Effortless Ready-to-Use <strong>Living</strong></h2><p style="text-align:center;white-space:pre-wrap;" class="">Each Space Cabin arrives 80% complete, featuring pre-installed plumbing and wiring, along with a fully finished bathroom and kitchen—ready for you to enjoy with ease.</p>
 </div>
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  
-  
-
-
-
 </div></div></div><div class="fe-block fe-block-9045ca526710e2cb8775"><div class="sqs-block image-block sqs-block-image sqs-stretched" data-aspect-ratio="100.09551098376312" data-block-type="5" id="block-9045ca526710e2cb8775"><div class="sqs-block-content">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  
-
-    
   
     <div
       class="
@@ -6294,29 +6225,8 @@ id="Gallery"
           
           style="overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);border-top-left-radius: 10px;border-top-right-radius: 10px;border-bottom-left-radius: 10px;border-bottom-right-radius: 10px;position: relative;width: 100%;height: 100%;"
         >
-          
-
-          
-          
-
-          
-            <a
-              class="sqs-block-image-link content-fill"
-              href=""
-              
-            >
-              
-            
-            
-            
-            
-            
-            
-            <img data-stretch="true" data-src="images.squarespace-cdn.com/new_images/Portable_Office.jpg" data-image="images.squarespace-cdn.com/new_images/Portable_Office.jpg" data-image-dimensions="800x800" data-image-focal-point="0.5,0.5" alt="" data-load="false" elementtiming="system-image-block" src="images.squarespace-cdn.com/content/v1/64b3b28ac7a0770c062fd14f/bfae91d5-eded-41a3-ab10-62907aaac062/the%2bstudio.jpg" width="800" height="800" alt="" sizes="100vw" style="display:block;object-fit: cover; object-position: 50% 50%" srcset="images.squarespace-cdn.com/new_images/Portable_Office.jpg?format=100w 100w, images.squarespace-cdn.com/new_images/Portable_Office.jpg?format=300w 300w, images.squarespace-cdn.com/new_images/Portable_Office.jpg?format=500w 500w, images.squarespace-cdn.com/new_images/Portable_Office.jpg?format=750w 750w, images.squarespace-cdn.com/new_images/Portable_Office.jpg?format=1000w 1000w, images.squarespace-cdn.com/new_images/Portable_Office.jpg?format=1500w 1500w, images.squarespace-cdn.com/new_images/Portable_Office.jpg?format=2500w 2500w" loading="lazy" decoding="async" data-loader="sqs">
-
-            
-              
-            
+            <a class="sqs-block-image-link content-fill" href="#footer-sections">
+            <img data-stretch="true" data-src="images.squarespace-cdn.com/new_images/Portable_Office.jpg" data-image="images.squarespace-cdn.com/new_images/Portable_Office.jpg" data-image-dimensions="800x800" data-image-focal-point="0.5,0.5" alt="" data-load="false" elementtiming="system-image-block" src="images.squarespace-cdn.com/content/v1/64b3b28ac7a0770c062fd14f/bfae91d5-eded-41a3-ab10-62907aaac062/the%2bstudio.jpg" width="800" height="800" alt="" sizes="100vw" style="display:block;object-fit: cover; object-position: 50% 50%" srcset="images.squarespace-cdn.com/new_images/Portable_Office.jpg?format=100w 100w, images.squarespace-cdn.com/new_images/Portable_Office.jpg?format=300w 300w, images.squarespace-cdn.com/new_images/Portable_Office.jpg?format=500w 500w, images.squarespace-cdn.com/new_images/Portable_Office.jpg?format=750w 750w, images.squarespace-cdn.com/new_images/Portable_Office.jpg?format=1000w 1000w, images.squarespace-cdn.com/new_images/Portable_Office.jpg?format=1500w 1500w, images.squarespace-cdn.com/new_images/Portable_Office.jpg?format=2500w 2500w" loading="lazy" decoding="async" data-loader="sqs">  
             <div class="fluidImageOverlay"></div>
           
             </a>
@@ -6372,50 +6282,6 @@ id="Gallery"
 </div></div></div><div class="fe-block fe-block-f9bff784de30420eac14"><div class="sqs-block image-block sqs-block-image sqs-stretched" data-aspect-ratio="100.09551098376312" data-block-type="5" id="block-f9bff784de30420eac14"><div class="sqs-block-content">
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  
-
-    
-  
     <div
       class="
         image-block-outer-wrapper
@@ -6445,28 +6311,10 @@ id="Gallery"
           
 
           
-            <a
-              class="sqs-block-image-link content-fill"
-              href=""
-              
-            >
-              
-            
-            
-            
-            
-            
-            
+            <a class="sqs-block-image-link content-fill" href="#footer-sections">
             <img data-stretch="true" data-src="images.squarespace-cdn.com/new_images/Space_Pod.jpg" data-image="images.squarespace-cdn.com/new_images/Space_Pod.jpg" data-image-dimensions="800x800" data-image-focal-point="0.5,0.5" alt="" data-load="false" elementtiming="system-image-block" src="images.squarespace-cdn.com/content/v1/64b3b28ac7a0770c062fd14f/0c3117e2-e5dc-4b80-b7f4-599d5270a2bd/designerpod.jpg" width="800" height="800" alt="" sizes="100vw" style="display:block;object-fit: cover; object-position: 50% 50%" srcset="images.squarespace-cdn.com/new_images/Space_Pod.jpg?format=100w 100w, images.squarespace-cdn.com/new_images/Space_Pod.jpg?format=300w 300w, images.squarespace-cdn.com/new_images/Space_Pod.jpg?format=500w 500w, images.squarespace-cdn.com/new_images/Space_Pod.jpg?format=750w 750w, images.squarespace-cdn.com/new_images/Space_Pod.jpg?format=1000w 1000w, images.squarespace-cdn.com/new_images/Space_Pod.jpg?format=1500w 1500w, images.squarespace-cdn.com/new_images/Space_Pod.jpg?format=2500w 2500w" loading="lazy" decoding="async" data-loader="sqs">
-
-            
-              
-            
             <div class="fluidImageOverlay"></div>
-          
             </a>
-          
-
         </div>
       </div>
     </div>
@@ -6484,15 +6332,8 @@ id="Gallery"
           width: 100%;
           height: 100%;
           mix-blend-mode: normal;
-          
-            
-            
-          
-          
             opacity: 0;
-          
         }
-      
     </style>
   
 
@@ -6507,76 +6348,8 @@ id="Gallery"
 </div>
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  
-  
-
-
-
 </div></div></div><div class="fe-block fe-block-6ba44d9ee351db6bbe0e"><div class="sqs-block image-block sqs-block-image sqs-stretched" data-aspect-ratio="100.09551098376312" data-block-type="5" id="block-6ba44d9ee351db6bbe0e"><div class="sqs-block-content">
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  
-
-    
-  
     <div
       class="
         image-block-outer-wrapper
@@ -6600,31 +6373,9 @@ id="Gallery"
           
           style="overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);border-top-left-radius: 10px;border-top-right-radius: 10px;border-bottom-left-radius: 10px;border-bottom-right-radius: 10px;position: relative;width: 100%;height: 100%;"
         >
-          
-
-          
-          
-
-          
-            <a
-              class="sqs-block-image-link content-fill"
-              href="/cabins/20ftmodule/"
-              
-            >
-              
-            
-            
-            
-            
-            
-            
+            <a class="sqs-block-image-link content-fill" href="/cabins/20ftmodule/">
             <img data-stretch="true" data-src="images.squarespace-cdn.com/new_images/20ft_Modular.png" data-image="images.squarespace-cdn.com/new_images/20ft_Modular.png" data-image-dimensions="800x800" data-image-focal-point="0.5,0.5" alt="" data-load="false" elementtiming="system-image-block" src="images.squarespace-cdn.com/content/v1/64b3b28ac7a0770c062fd14f/5f1496b3-894e-4d0f-867e-11a419816b92/20ft%2bMODULAR.jpg" width="800" height="800" alt="" sizes="100vw" style="display:block;object-fit: cover; object-position: 50% 50%" srcset="images.squarespace-cdn.com/new_images/20ft_Modular.png?format=100w 100w, images.squarespace-cdn.com/new_images/20ft_Modular.png?format=300w 300w, images.squarespace-cdn.com/new_images/20ft_Modular.png?format=500w 500w, images.squarespace-cdn.com/new_images/20ft_Modular.png?format=750w 750w, images.squarespace-cdn.com/new_images/20ft_Modular.png?format=1000w 1000w, images.squarespace-cdn.com/new_images/20ft_Modular.png?format=1500w 1500w, images.squarespace-cdn.com/new_images/20ft_Modular.png?format=2500w 2500w" loading="lazy" decoding="async" data-loader="sqs">
-
-            
-              
-            
-            <div class="fluidImageOverlay"></div>
-          
+            <div class="fluidImageOverlay"></div> 
             </a>
           
 
@@ -6645,13 +6396,7 @@ id="Gallery"
           width: 100%;
           height: 100%;
           mix-blend-mode: normal;
-          
-            
-            
-          
-          
             opacity: 0;
-          
         }
       
     </style>
@@ -6667,77 +6412,8 @@ id="Gallery"
   <h3 style="white-space:pre-wrap;"><span class="sqsrte-text-color--white"><strong>20FT MODULAR</strong></span></h3>
 </div>
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  
-  
-
-
-
 </div></div></div><div class="fe-block fe-block-60861a5ba43b708afc3d"><div class="sqs-block image-block sqs-block-image sqs-stretched" data-aspect-ratio="100.09551098376312" data-block-type="5" id="block-60861a5ba43b708afc3d"><div class="sqs-block-content">
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  
-
-    
-  
     <div
       class="
         image-block-outer-wrapper
@@ -6761,31 +6437,11 @@ id="Gallery"
           
           style="overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);border-top-left-radius: 10px;border-top-right-radius: 10px;border-bottom-left-radius: 10px;border-bottom-right-radius: 10px;position: relative;width: 100%;height: 100%;"
         >
-          
-
-          
-          
-
-          
             <a
               class="sqs-block-image-link content-fill"
-              href="/cabins/30ftmodule/"
-              
-            >
-              
-            
-            
-            
-            
-            
-            
+              href="/cabins/30ftmodule/">
              <img data-stretch="true" data-src="images.squarespace-cdn.com/new_images/30ft_Modular.jpg" data-image="images.squarespace-cdn.com/new_images/30ft_Modular.jpg" data-image-dimensions="800x800" data-image-focal-point="0.5,0.5" alt="" data-load="false" elementtiming="system-image-block" src="images.squarespace-cdn.com/content/v1/64b3b28ac7a0770c062fd14f/6c53edba-c2a5-4b0b-92c8-69565534d70a/30ft%2bMODULAR.jpg" width="800" height="800" alt="" sizes="100vw" style="display:block;object-fit: cover; object-position: 50% 50%" srcset="images.squarespace-cdn.com/new_images/30ft_Modular.jpg?format=100w 100w, images.squarespace-cdn.com/new_images/30ft_Modular.jpg?format=300w 300w, images.squarespace-cdn.com/new_images/30ft_Modular.jpg?format=500w 500w, images.squarespace-cdn.com/new_images/30ft_Modular.jpg?format=750w 750w, images.squarespace-cdn.com/new_images/30ft_Modular.jpg?format=1000w 1000w, images.squarespace-cdn.com/new_images/30ft_Modular.jpg?format=1500w 1500w, images.squarespace-cdn.com/new_images/30ft_Modular.jpg?format=2500w 2500w" loading="lazy" decoding="async" data-loader="sqs">
-
-            
-              
-            
-            <div class="fluidImageOverlay"></div>
-          
+             <div class="fluidImageOverlay"></div>
             </a>
           
 
@@ -6806,13 +6462,7 @@ id="Gallery"
           width: 100%;
           height: 100%;
           mix-blend-mode: normal;
-          
-            
-            
-          
-          
             opacity: 0;
-          
         }
       
     </style>
@@ -6828,76 +6478,7 @@ id="Gallery"
   <h3 style="white-space:pre-wrap;"><span class="sqsrte-text-color--white"><strong>30FT MODULAR</strong></span></h3>
 </div>
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  
-  
-
-
-
 </div></div></div><div class="fe-block fe-block-057ce2a15f019abd3fd6"><div class="sqs-block image-block sqs-block-image sqs-stretched" data-aspect-ratio="100.09551098376312" data-block-type="5" id="block-057ce2a15f019abd3fd6"><div class="sqs-block-content">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  
-
-    
   
     <div
       class="
@@ -6913,42 +6494,16 @@ id="Gallery"
       <div
         class="fluid-image-animation-wrapper sqs-image sqs-block-alignment-wrapper"
         data-animation-role="image"
-        
-  
-
       >
         <div
           class="fluid-image-container sqs-image-content"
           
           style="overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);border-top-left-radius: 10px;border-top-right-radius: 10px;border-bottom-left-radius: 10px;border-bottom-right-radius: 10px;position: relative;width: 100%;height: 100%;"
-        >
-          
-
-          
-          
-
-          
-            <a
-              class="sqs-block-image-link content-fill"
-              href="/cabins/40ftmodule/"
-              
-            >
-              
-            
-            
-            
-            
-            
-            
+        > 
+            <a class="sqs-block-image-link content-fill" href="/cabins/40ftmodule/"> 
             <img data-stretch="true" data-src="images.squarespace-cdn.com/new_images/40ft_Modular.png" data-image="images.squarespace-cdn.com/new_images/40ft_Modular.png" data-image-dimensions="800x800" data-image-focal-point="0.5,0.5" alt="" data-load="false" elementtiming="system-image-block" src="images.squarespace-cdn.com/content/v1/64b3b28ac7a0770c062fd14f/7ff44085-ef54-45c3-b907-2b3c970933f1/40ft%2bMODULAR.jpg" width="800" height="800" alt="" sizes="100vw" style="display:block;object-fit: cover; object-position: 50% 50%" srcset="images.squarespace-cdn.com/new_images/40ft_Modular.png?format=100w 100w, images.squarespace-cdn.com/new_images/40ft_Modular.png?format=300w 300w, images.squarespace-cdn.com/new_images/40ft_Modular.png?format=500w 500w, images.squarespace-cdn.com/new_images/40ft_Modular.png?format=750w 750w, images.squarespace-cdn.com/new_images/40ft_Modular.png?format=1000w 1000w, images.squarespace-cdn.com/new_images/40ft_Modular.png?format=1500w 1500w, images.squarespace-cdn.com/new_images/40ft_Modular.png?format=2500w 2500w" loading="lazy" decoding="async" data-loader="sqs">
-
-            
-              
-            
             <div class="fluidImageOverlay"></div>
-          
-            </a>
-          
+            </a>          
 
         </div>
       </div>
@@ -6967,15 +6522,8 @@ id="Gallery"
           width: 100%;
           height: 100%;
           mix-blend-mode: normal;
-          
-            
-            
-          
-          
             opacity: 0;
-          
         }
-      
     </style>
   
 
@@ -6990,75 +6538,7 @@ id="Gallery"
 </div>
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  
-  
-
-
-
 </div></div></div><div class="fe-block fe-block-1775221c53216658a5c9"><div class="sqs-block image-block sqs-block-image sqs-stretched" data-aspect-ratio="100.09551098376312" data-block-type="5" id="block-1775221c53216658a5c9"><div class="sqs-block-content">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  
-
-    
   
     <div
       class="
@@ -7089,23 +6569,8 @@ id="Gallery"
           
 
           
-            <a
-              class="sqs-block-image-link content-fill"
-              href=""
-              
-            >
-              
-            
-            
-            
-            
-            
-            
+            <a class="sqs-block-image-link content-fill" href="#footer-sections">
             <img data-stretch="true" data-src="images.squarespace-cdn.com/new_images/Open-layout.png" data-image="images.squarespace-cdn.com/new_images/Open-layout.png" data-image-dimensions="800x800" data-image-focal-point="0.5,0.5" alt="" data-load="false" elementtiming="system-image-block" src="images.squarespace-cdn.com/content/v1/64b3b28ac7a0770c062fd14f/64e83c13-1ba2-4ff2-affd-b822619b5d47/the%2bsanctuary.jpg" width="800" height="800" alt="" sizes="100vw" style="display:block;object-fit: cover; object-position: 50% 50%" srcset="images.squarespace-cdn.com/new_images/Open-layout.png?format=100w 100w, images.squarespace-cdn.com/new_images/Open-layout.png?format=300w 300w, images.squarespace-cdn.com/new_images/Open-layout.png?format=500w 500w, images.squarespace-cdn.com/new_images/Open-layout.png?format=750w 750w, images.squarespace-cdn.com/new_images/Open-layout.png?format=1000w 1000w, images.squarespace-cdn.com/new_images/Open-layout.png?format=1500w 1500w, images.squarespace-cdn.com/new_images/Open-layout.png?format=2500w 2500w" loading="lazy" decoding="async" data-loader="sqs">
-
-            
-              
-            
             <div class="fluidImageOverlay"></div>
           
             </a>
@@ -7128,13 +6593,7 @@ id="Gallery"
           width: 100%;
           height: 100%;
           mix-blend-mode: normal;
-          
-            
-            
-          
-          
             opacity: 0;
-          
         }
       
     </style>
@@ -7149,30 +6608,6 @@ id="Gallery"
 <div class="sqs-html-content">
   <h3 style="white-space:pre-wrap;"><span class="sqsrte-text-color--white"><strong>OPEN-LAYOUT</strong></span></h3>
 </div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  
-  
-
-
 
 </div></div></div></div></div>
     </div>
@@ -9849,7 +9284,7 @@ id="ContactUs"
     <div class="sqs-html-content">
       <p class="" style="white-space:pre-wrap;"><a href="" style="text-decoration: none;"><strong>HOMEPAGE</strong></a></p>
       <p class="" style="white-space:pre-wrap;"><a href="#Gallery" style="text-decoration: none;"><strong>CABINS</strong></a></p>
-      <p class="" style="white-space:pre-wrap;"><a href="" style="text-decoration: none;"><strong>SPACE CAPSULE</strong></a></p>
+      <!-- <p class="" style="white-space:pre-wrap;"><a href="" style="text-decoration: none;"><strong>SPACE CAPSULE</strong></a></p> -->
       <p class="" style="white-space:pre-wrap;"><a href="" style="text-decoration: none;"><strong>ABOUT US</strong></a></p>
       <p class="" style="white-space:pre-wrap;"><a href="" style="text-decoration: none;"><strong>BLOG</strong></a></p>
       <p class="" style="white-space:pre-wrap;"><a href="#ContactUs" style="text-decoration: none;"><strong>CONTACT</strong></a></p>


### PR DESCRIPTION
Remove Space Pods Menu
- Dead page (no ready page)
- Creating a new page will not make sense due to pending migration to wordpress

Fix Gallery and About Us Routing Issue
- Gallery - Homepage only: route to footer
- About Us: Route to footer